### PR TITLE
Make this be unicode

### DIFF
--- a/sourcemap/decoder.py
+++ b/sourcemap/decoder.py
@@ -165,5 +165,5 @@ class SourceMapDecoder(object):
 # Mapping of base64 letter -> integer value.
 B64 = dict(
     (c, i) for i, c in
-    enumerate('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/')
+    enumerate(u'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/')
 )


### PR DESCRIPTION
I'm pretty sure this will make stuff be faster on PyPy, since you index into it with a unicode.
