### PR TITLE
Added __slots__ to Token class to save some memory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ python:
  - "2.6"
  - "2.7"
  - "3.3"
+ - "3.4"
+ - "3.5"
  - "pypy"
 install: 
  - "pip install -e ."

--- a/sourcemap/objects.py
+++ b/sourcemap/objects.py
@@ -19,6 +19,9 @@ class Token(object):
         Source column number: src_col
         Name of the token: name
     """
+
+    __slots__ = ['dst_line', 'dst_col', 'src', 'src_line', 'src_col', 'name']
+
     def __init__(self, dst_line=0, dst_col=0, src='', src_line=0, src_col=0, name=None):
         self.dst_line = dst_line
         self.dst_col = dst_col


### PR DESCRIPTION
When loading about 160 MByte worth of sourcemaps, this cut memory usage more or less by half, and also increases parsing speed a bit.

    # before
    pfullmem(rss=5845102592L, vms=11115905024L, pfaults=2213604, pageins=0, uss=5863231488L)
    69.420s total

    # after
    pfullmem(rss=2217996288L, vms=4820193280L, pfaults=655818, pageins=53, uss=2259755008L)
    49.173s total

These numbers are from CPython 2.7.11 on OSX. CPython 3.5.1 has more or less the same numbers. Unsurprisingly, pypy does not benefit from this change, but it doesn't suffer from them, either.