### PR TITLE
Python 3.x map issue

### DIFF
--- a/sourcemap/decoder.py
+++ b/sourcemap/decoder.py
@@ -115,7 +115,8 @@ class SourceMapDecoder(object):
         lines = mappings.split(';')
 
         if sourceRoot is not None:
-            sources = map(partial(os.path.join, sourceRoot), sources)
+            # Python 3.x doesn't return a list type
+            sources = list(map(partial(os.path.join, sourceRoot), sources))
 
         # List of all tokens
         tokens = []


### PR DESCRIPTION
Fixed issue with map function in Python 3.x.
http://stackoverflow.com/questions/21572840/map-object-has-no-len-in-python-3-3
